### PR TITLE
bfsa: abstract storage

### DIFF
--- a/bfsa/bucket.go
+++ b/bfsa/bucket.go
@@ -1,0 +1,144 @@
+package bfsa
+
+import (
+	"context"
+	"io"
+
+	"github.com/bsm/bfs"
+)
+
+type bucket struct {
+	reg registry
+}
+
+func New(opts ...Option) (bfs.Bucket, error) {
+	var b bucket
+	for _, opt := range opts {
+		if err := opt.setup(&b); err != nil {
+			return nil, err
+		}
+	}
+	return &b, nil
+}
+
+// Glob lists the files mathing a glob pattern.
+func (b *bucket) Glob(ctx context.Context, pattern string) (bfs.Iterator, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	bucket, path, toURI, err := b.resolve(ctx, pattern)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	it, err := bucket.Glob(ctx, path)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	return &iterator{
+		Iterator: it,
+		toURI:    toURI,
+		closer: func(err error) error {
+			_ = bucket.Close()
+			cancel()
+			return err
+		},
+	}, nil
+}
+
+// Head returns an object's meta Info.
+func (b *bucket) Head(ctx context.Context, name string) (*bfs.MetaInfo, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	bucket, path, _, err := b.resolve(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	defer bucket.Close()
+
+	return bucket.Head(ctx, path)
+}
+
+// Open opens an object for reading.
+func (b *bucket) Open(ctx context.Context, name string) (io.ReadCloser, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	bucket, path, _, err := b.resolve(ctx, name)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	rc, err := bucket.Open(ctx, path)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	return &readCloser{
+		ReadCloser: rc,
+		closer: func(err error) error {
+			_ = bucket.Close()
+			cancel()
+			return err
+		},
+	}, nil
+}
+
+// Create creates/opens a object for writing.
+func (b *bucket) Create(ctx context.Context, name string) (io.WriteCloser, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	bucket, path, _, err := b.resolve(ctx, name)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	wc, err := bucket.Create(ctx, path)
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+
+	return &writeCloser{
+		WriteCloser: wc,
+		closer: func(err error) error {
+			_ = bucket.Close()
+			cancel()
+			return err
+		},
+	}, nil
+}
+
+// Remove removes a object.
+func (b *bucket) Remove(ctx context.Context, name string) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	bucket, path, _, err := b.resolve(ctx, name)
+	if err != nil {
+		return err
+	}
+	defer bucket.Close()
+
+	return bucket.Remove(ctx, path)
+}
+
+// Close closes the bucket.
+func (b *bucket) Close() error {
+	return nil
+}
+
+func (b *bucket) resolve(ctx context.Context, uri string) (bfs.Bucket, string, func(string) string, error) {
+	bucket, path, toURI, err := b.reg.resolve(ctx, uri)
+	if _, ok := err.(unsupportedSchemeError); !ok {
+		return bucket, path, toURI, err
+	}
+	return reg.resolve(ctx, uri)
+}
+
+var _ bfs.Bucket = &bucket{}

--- a/bfsa/detect_scheme.go
+++ b/bfsa/detect_scheme.go
@@ -1,0 +1,11 @@
+package bfsa
+
+import "strings"
+
+func detectScheme(uri string) string {
+	res := strings.SplitAfterN(uri, "//", 2)
+	if len(res) != 2 {
+		return ""
+	}
+	return res[0]
+}

--- a/bfsa/error.go
+++ b/bfsa/error.go
@@ -1,0 +1,11 @@
+package bfsa
+
+import "fmt"
+
+type unsupportedSchemeError struct {
+	Scheme string
+}
+
+func (e unsupportedSchemeError) Error() string {
+	return fmt.Sprintf("bfsa: unsupported scheme %q", e.Scheme)
+}

--- a/bfsa/iterator.go
+++ b/bfsa/iterator.go
@@ -1,0 +1,18 @@
+package bfsa
+
+import "github.com/bsm/bfs"
+
+type iterator struct {
+	bfs.Iterator
+	toURI  func(string) string
+	closer func(error) error
+}
+
+func (c *iterator) Name() string {
+	name := c.Iterator.Name()
+	return c.toURI(name)
+}
+
+func (c *iterator) Close() error {
+	return c.closer(c.Iterator.Close())
+}

--- a/bfsa/option.go
+++ b/bfsa/option.go
@@ -1,0 +1,20 @@
+package bfsa
+
+type Option interface {
+	setup(*bucket) error
+}
+
+func WithResolver(scheme string, resolver Resolver) Option {
+	return optionFunc(func(b *bucket) error {
+		b.reg.Register(scheme, resolver)
+		return nil
+	})
+}
+
+// ----------------------------------------------------------------------------
+
+type optionFunc func(*bucket) error
+
+func (f optionFunc) setup(b *bucket) error {
+	return f(b)
+}

--- a/bfsa/read_closer.go
+++ b/bfsa/read_closer.go
@@ -1,0 +1,12 @@
+package bfsa
+
+import "io"
+
+type readCloser struct {
+	io.ReadCloser
+	closer func(error) error
+}
+
+func (c *readCloser) Close() error {
+	return c.closer(c.ReadCloser.Close())
+}

--- a/bfsa/registry.go
+++ b/bfsa/registry.go
@@ -1,0 +1,39 @@
+package bfsa
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/bsm/bfs"
+)
+
+var reg registry
+
+func init() {
+	reg = registry{}
+}
+
+func Register(scheme string, resolver Resolver) {
+	reg.Register(scheme, resolver)
+}
+
+// ----------------------------------------------------------------------------
+
+type registry map[string]Resolver
+
+func (r registry) Register(scheme string, resolver Resolver) {
+	r[scheme] = resolver
+}
+
+func (r registry) resolve(ctx context.Context, uri string) (bfs.Bucket, string, func(string) string, error) {
+	scheme := detectScheme(uri)
+	if scheme == "" {
+		return nil, "", nil, fmt.Errorf("no scheme in %q", uri)
+	}
+
+	resolver, ok := r[uri]
+	if !ok {
+		return nil, "", nil, unsupportedSchemeError{Scheme: scheme}
+	}
+	return resolver(ctx, uri)
+}

--- a/bfsa/resolver.go
+++ b/bfsa/resolver.go
@@ -1,0 +1,14 @@
+package bfsa
+
+import (
+	"context"
+
+	"github.com/bsm/bfs"
+)
+
+type Resolver func(ctx context.Context, uri string) (
+	bucket bfs.Bucket,
+	path string,
+	toURI func(name string) (uri string),
+	err error,
+)

--- a/bfsa/write_closer.go
+++ b/bfsa/write_closer.go
@@ -1,0 +1,12 @@
+package bfsa
+
+import "io"
+
+type writeCloser struct {
+	io.WriteCloser
+	closer func(error) error
+}
+
+func (c *writeCloser) Close() error {
+	return c.closer(c.WriteCloser.Close())
+}

--- a/bfsfs/bfsa_registration.go
+++ b/bfsfs/bfsa_registration.go
@@ -1,0 +1,33 @@
+package bfsfs
+
+import (
+	"context"
+	"strings"
+
+	"github.com/bsm/bfs"
+	"github.com/bsm/bfs/bfsa"
+)
+
+// DefaultScheme is a recommended scheme for local file system.
+const DefaultScheme = "file://"
+
+// Register registers abstract storage, backed by local file system with given root and tmpDir, for specified schema.
+func Register(scheme, root, tmpDir string) {
+	resolver := func(ctx context.Context, uri string) (
+		bfs.Bucket,
+		string,
+		func(name string) (uri string),
+		error,
+	) {
+		bucket, err := New(root, tmpDir)
+		if err != nil {
+			return nil, "", nil, err
+		}
+
+		path := strings.TrimPrefix(uri, scheme)
+		return bucket, path, func(name string) string {
+			return scheme + name
+		}, nil
+	}
+	bfsa.Register(scheme, resolver)
+}


### PR DESCRIPTION
Dirty proof-of-concept. Not mergeable, needs polishing and tests, if such approach is acceptable for this project.

Motivation:

It's usually easier to have one store which can:
- switch between filesystem implementations by scheme (like `gs://bucket/path/to/file.bin` / `file://bucket/path/to/file.bin`)
- switch between buckets on the fly (if you need to work with multiple buckets - they may not be known in advance so cannot be pre-constructed)

So I've done something that can be used like this:

```
import (
  ".../bfs/bfsa"
  ".../bfs/bfsfs"
)

func init() {
  bfsfs.Register("file://", "path/to/root", "path/to/tmp") // globally extensible
  
  // or, can be also done - probs, even more explicit:
  bfsa.Register("custom://", custompkg.Resolver(...))
}

func main() {
  ...

  store := bfsa.New(
    bfsa.WithResolver("custom://", custompkg.Resolver(...)), // extensible per instance
  )

  it, err := store.Glob(ctx, "file://path/to/*.bin")
  w, err := store.Glob(ctx, "file://path/to/file.bin")
  r, err := store.Open(ctx, "file://path/to/file.bin")
  err := store.Remove(ctx, "file://path/to/file.bin") 
}
```

Ideally, `bfsa` subpackage should be merged into root `bfs` package to provide abstract storage by default.

I think it's already over-engineered as for proof of concept. Can (should?) be simplified (for example, it may not export `bfsa.New` and just provide global `bfsa.Open/Create/Glob/Remove` functions).

It's also, well, a bit too heavy (abstractions, wrappers for almost everything) - but that's the only approach I came up with so far.