### PR TITLE
Feature/cancel context

### DIFF
--- a/bfsfs/bfsfs.go
+++ b/bfsfs/bfsfs.go
@@ -77,14 +77,14 @@ func openAtomicFile(ctx context.Context, name string, tmpDir string) (*atomicFil
 func (f *atomicFile) Close() error {
 	defer f.cleanup()
 
+	if err := f.File.Close(); err != nil {
+		return err
+	}
+
 	select {
 	case <-f.ctx.Done():
 		return f.ctx.Err()
 	default:
-	}
-
-	if err := f.File.Close(); err != nil {
-		return err
 	}
 
 	if err := os.MkdirAll(filepath.Dir(f.name), 0777); err != nil {

--- a/bfsfs/bfsfs.go
+++ b/bfsfs/bfsfs.go
@@ -79,7 +79,7 @@ func (f *atomicFile) Close() error {
 
 	select {
 	case <-f.ctx.Done():
-		return nil
+		return f.ctx.Err()
 	default:
 	}
 

--- a/bfsfs/bucket.go
+++ b/bfsfs/bucket.go
@@ -75,7 +75,7 @@ func (b *bucket) Open(ctx context.Context, name string) (io.ReadCloser, error) {
 
 // Create creates/opens a object for writing.
 func (b *bucket) Create(ctx context.Context, name string) (io.WriteCloser, error) {
-	f, err := openAtomicFile(b.resolve(name), b.tmpDir)
+	f, err := openAtomicFile(ctx, b.resolve(name), b.tmpDir)
 	if err != nil {
 		return nil, normError(err)
 	}

--- a/inmem.go
+++ b/inmem.go
@@ -134,7 +134,7 @@ type inMemWriter struct {
 func (w *inMemWriter) Close() error {
 	select {
 	case <-w.ctx.Done():
-		return nil
+		return w.ctx.Err()
 	default:
 	}
 

--- a/inmem.go
+++ b/inmem.go
@@ -70,8 +70,8 @@ func (b *InMem) Open(_ context.Context, name string) (io.ReadCloser, error) {
 }
 
 // Create implements Bucket.
-func (b *InMem) Create(_ context.Context, name string) (io.WriteCloser, error) {
-	return &inMemWriter{bucket: b, name: name}, nil
+func (b *InMem) Create(ctx context.Context, name string) (io.WriteCloser, error) {
+	return &inMemWriter{ctx: ctx, bucket: b, name: name}, nil
 }
 
 // Remove implements Bucket.
@@ -126,11 +126,18 @@ func (*inMemReader) Close() error { return nil }
 type inMemWriter struct {
 	bytes.Buffer
 
+	ctx    context.Context
 	bucket *InMem
 	name   string
 }
 
 func (w *inMemWriter) Close() error {
+	select {
+	case <-w.ctx.Done():
+		return nil
+	default:
+	}
+
 	w.bucket.store(w.name, w.Bytes())
 	return nil
 }


### PR DESCRIPTION
dont write files if context cancelled in InMem and FS implementations, to better mock GCS and S3 writer behaviour.