### PR TITLE
bfsfs: fix root path building

### DIFF
--- a/bfsfs/bfsfs.go
+++ b/bfsfs/bfsfs.go
@@ -29,6 +29,7 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/bsm/bfs"
@@ -36,8 +37,9 @@ import (
 
 func init() {
 	bfs.Register("file", func(_ context.Context, u *url.URL) (bfs.Bucket, error) {
+		root := path.Join(u.Host, u.Path) // to handle special relative cases like: "file://this-works-like-a-host/path..."
 		q := u.Query()
-		return New(u.Path, q.Get("tmpdir"))
+		return New(root, q.Get("tmpdir"))
 	})
 }
 

--- a/bfsfs/bucket.go
+++ b/bfsfs/bucket.go
@@ -50,7 +50,8 @@ func (b *bucket) Glob(_ context.Context, pattern string) (bfs.Iterator, error) {
 		if fi, err := os.Stat(match); err != nil {
 			return nil, normError(err)
 		} else if fi.Mode().IsRegular() {
-			files = append(files, strings.TrimPrefix(match, b.fsRoot))
+			fsPath := strings.TrimPrefix(match, b.fsRoot) // filesystem path (with OS-specific separators)
+			files = append(files, filepath.ToSlash(fsPath))
 		}
 	}
 	return newIterator(files), nil

--- a/object.go
+++ b/object.go
@@ -38,7 +38,7 @@ func NewObject(ctx context.Context, fullURL string) (*Object, error) {
 
 	// store full path name and unset
 	name := strings.TrimPrefix(path.Clean(u.Path), "/")
-	u.Path = ""
+	u.Path = "/"
 
 	// resolve bucket
 	bucket, err := Resolve(ctx, u)


### PR DESCRIPTION
Now it should work fine with:
- `file://./rel/path` (already worked)
- `file://rel/path` (was broken)
- `file:///abs/path` (was broken)