### PR TITLE
Added a `Meta() *MetaInfo` method to `Iterator`

### DIFF
--- a/bfs.go
+++ b/bfs.go
@@ -76,6 +76,8 @@ type Iterator interface {
 	Next() bool
 	// Name returns the name at the current cursor position.
 	Name() string
+	// Meta returns the meta information for the current object.
+	Meta() *MetaInfo
 	// Error returns the last iterator error, if any.
 	Error() error
 	// Close closes the iterator, should always be deferred.

--- a/bfs.go
+++ b/bfs.go
@@ -66,8 +66,8 @@ type MetaInfo struct {
 	Name        string            // base name of the object
 	Size        int64             // length of the content in bytes
 	ModTime     time.Time         // modification time
-	ContentType string            // optional content type
-	Metadata    map[string]string // optional metadata
+	ContentType string            // content type
+	Metadata    map[string]string // metadata
 }
 
 // Iterator iterates over objects
@@ -76,8 +76,10 @@ type Iterator interface {
 	Next() bool
 	// Name returns the name at the current cursor position.
 	Name() string
-	// Meta returns the meta information for the current object.
-	Meta() *MetaInfo
+	// Size returns the length of the content in bytes for the current object.
+	Size() int64
+	// ModTime returns the modification time for the current object.
+	ModTime() time.Time
 	// Error returns the last iterator error, if any.
 	Error() error
 	// Close closes the iterator, should always be deferred.

--- a/bfsfs/bucket.go
+++ b/bfsfs/bucket.go
@@ -52,7 +52,11 @@ func (b *bucket) Glob(_ context.Context, pattern string) (bfs.Iterator, error) {
 		} else if fi.Mode().IsRegular() {
 			fsPath := strings.TrimPrefix(match, b.fsRoot) // filesystem path (with OS-specific separators)
 			name := filepath.ToSlash(fsPath)
-			files = append(files, file{name: name, meta: newMetaInfo(name, fi)})
+			files = append(files, file{
+				name:    name,
+				size:    fi.Size(),
+				modTime: fi.ModTime(),
+			})
 		}
 	}
 	return newIterator(files), nil
@@ -64,15 +68,11 @@ func (b *bucket) Head(ctx context.Context, name string) (*bfs.MetaInfo, error) {
 	if err != nil {
 		return nil, normError(err)
 	}
-	return newMetaInfo(name, fi), nil
-}
-
-func newMetaInfo(name string, fi os.FileInfo) *bfs.MetaInfo {
 	return &bfs.MetaInfo{
 		Name:    name,
 		Size:    fi.Size(),
 		ModTime: fi.ModTime(),
-	}
+	}, nil
 }
 
 // Open implements bfs.Bucket

--- a/bfsfs/bucket.go
+++ b/bfsfs/bucket.go
@@ -45,14 +45,14 @@ func (b *bucket) Glob(_ context.Context, pattern string) (bfs.Iterator, error) {
 		return nil, normError(err)
 	}
 
-	files := make([]file, 0)
+	files := make([]file, 0, len(matches))
 	for _, match := range matches {
 		if fi, err := os.Stat(match); err != nil {
 			return nil, normError(err)
 		} else if fi.Mode().IsRegular() {
 			fsPath := strings.TrimPrefix(match, b.fsRoot) // filesystem path (with OS-specific separators)
 			name := filepath.ToSlash(fsPath)
-			files = append(files, file{name, newMetaInfo(name, fi)})
+			files = append(files, file{name: name, meta: newMetaInfo(name, fi)})
 		}
 	}
 	return newIterator(files), nil

--- a/bfsfs/iterator.go
+++ b/bfsfs/iterator.go
@@ -1,17 +1,26 @@
 package bfsfs
 
-// iterator implements an iterator over file path list.
+import (
+	"github.com/bsm/bfs"
+)
+
+// iterator implements an iterator over file list.
 type iterator struct {
-	names []string // hold relative (non-rooted) file names/paths
+	files []file // hold relative (non-rooted) files
 	index int
+}
+
+type file struct {
+	name string
+	meta *bfs.MetaInfo
 }
 
 // newIterator constructs new iterator.
 //
 // WARNING! Iterator uses provided names slice, so it shouldn't be mutated after being passed here.
-func newIterator(names []string) *iterator {
+func newIterator(files []file) *iterator {
 	return &iterator{
-		names: names,
+		files: files,
 		index: -1,
 	}
 }
@@ -25,9 +34,17 @@ func (it *iterator) Next() bool {
 // Name returns the name at the current cursor position.
 func (it *iterator) Name() string {
 	if it.isValid() {
-		return it.names[it.index]
+		return it.files[it.index].name
 	}
 	return ""
+}
+
+// Meta returns the *bfs.MetaInfo at the current cursor position.
+func (it *iterator) Meta() *bfs.MetaInfo {
+	if it.isValid() {
+		return it.files[it.index].meta
+	}
+	return nil
 }
 
 // Error returns the last iterator error, if any.
@@ -37,11 +54,11 @@ func (it *iterator) Error() error {
 
 // Close closes the iterator, should always be deferred.
 func (it *iterator) Close() error {
-	it.names = nil
+	it.files = nil
 	return nil
 }
 
 // isValid tells if current iterator is valid (not exhausted).
 func (it *iterator) isValid() bool {
-	return it.index < len(it.names)
+	return it.index < len(it.files)
 }

--- a/bfsfs/iterator.go
+++ b/bfsfs/iterator.go
@@ -1,7 +1,7 @@
 package bfsfs
 
 import (
-	"github.com/bsm/bfs"
+	"time"
 )
 
 // iterator implements an iterator over file list.
@@ -11,8 +11,9 @@ type iterator struct {
 }
 
 type file struct {
-	name string
-	meta *bfs.MetaInfo
+	name    string
+	size    int64
+	modTime time.Time
 }
 
 // newIterator constructs new iterator.
@@ -39,12 +40,20 @@ func (it *iterator) Name() string {
 	return ""
 }
 
-// Meta returns the *bfs.MetaInfo at the current cursor position.
-func (it *iterator) Meta() *bfs.MetaInfo {
+// Size returns the content length in bytes at the current cursor position.
+func (it *iterator) Size() int64 {
 	if it.isValid() {
-		return it.files[it.index].meta
+		return it.files[it.index].size
 	}
-	return nil
+	return 0
+}
+
+// ModTime returns the modification time at the current cursor position.
+func (it *iterator) ModTime() time.Time {
+	if it.isValid() {
+		return it.files[it.index].modTime
+	}
+	return time.Time{}
 }
 
 // Error returns the last iterator error, if any.

--- a/bfsgs/bfsgs.go
+++ b/bfsgs/bfsgs.go
@@ -231,7 +231,7 @@ func (i *iterator) Next() bool {
 			i.err = err
 			return false
 		} else if ok {
-			i.current = object{name, newMetaInfo(name, obj)}
+			i.current = object{name: name, meta: newMetaInfo(name, obj)}
 			return true
 		}
 	}

--- a/inmem.go
+++ b/inmem.go
@@ -168,12 +168,18 @@ func (i *inMemIterator) Name() string {
 	return ""
 }
 
-func (i *inMemIterator) Meta() *MetaInfo {
+func (i *inMemIterator) Size() int64 {
 	if i.pos < len(i.entries) {
-		meta := i.entries[i.pos].info
-		return &meta
+		return i.entries[i.pos].info.Size
 	}
-	return nil
+	return 0
+}
+
+func (i *inMemIterator) ModTime() time.Time {
+	if i.pos < len(i.entries) {
+		return i.entries[i.pos].info.ModTime
+	}
+	return time.Time{}
 }
 
 func (*inMemIterator) Error() error { return nil }


### PR DESCRIPTION
All current implementations of `bfs.Iterator` already have enough information to construct a `MetaInfo` without making any additional calls to the underlying store.