### PR TITLE
Allow for relative paths for scp, default to absolute

### DIFF
--- a/bfsscp/bfsscp.go
+++ b/bfsscp/bfsscp.go
@@ -10,7 +10,7 @@
 //
 //   func main() {
 //     ctx := context.Background()
-//     b, _ := bfs.Connect(ctx, "ssh://user:pass@hostname:22/path/to/root?tmpdir=%2Fcustom%2Ftmp&absolute=true")
+//     b, _ := bfs.Connect(ctx, "ssh://user:pass@hostname:22/path/to/root?tmpdir=%2Fcustom%2Ftmp")
 //     f, _ := b.Open(ctx, "file/within/root.txt")
 //     ...
 //   }
@@ -18,7 +18,6 @@
 // bfs.Connect supports the following query parameters:
 //
 //   tmpdir - custom temp dir
-//   absolute - to keep the inital slash for prefix, making it an absolute path
 //
 package bfsscp
 
@@ -59,7 +58,6 @@ func init() {
 			Password: password,
 			Prefix:   u.Path,
 			TempDir:  query.Get("tmpdir"),
-			Absolute: query.Get("absolute") == "true",
 		})
 	})
 }
@@ -74,20 +72,12 @@ type Config struct {
 	Prefix string
 	// A custom temp dir.
 	TempDir string
-	// Whether Prefix Paths are absolute or relative
-	Absolute bool
 }
 
 func (c *Config) norm() error {
-	// By default prefixes should start in the user's dir
-	if !c.Absolute {
-		c.Prefix = strings.TrimPrefix(c.Prefix, "/")
-	}
-
-	// Ensure even blank prefixes use slash when absolute path is prefered
-	if c.Absolute && c.Prefix == "" {
-		c.Prefix = "/"
-	}
+	// If prefix indicates starting in the user's dir, trim
+	c.Prefix = strings.TrimPrefix(c.Prefix, "/~/")
+	c.Prefix = strings.TrimPrefix(c.Prefix, "/./")
 
 	// Add a trailing slash when one doesn't exist
 	if c.Prefix != "" && !strings.HasSuffix(c.Prefix, "/") {

--- a/bfsscp/bfsscp_test.go
+++ b/bfsscp/bfsscp_test.go
@@ -19,6 +19,7 @@ const (
 
 var _ = Describe("Bucket", func() {
 	var opts lint.Options
+	var ctx = context.Background()
 
 	BeforeEach(func() {
 		prefix := "x/" + strconv.FormatInt(time.Now().UnixNano(), 10)
@@ -31,8 +32,31 @@ var _ = Describe("Bucket", func() {
 	})
 
 	It("should register scp scheme", func() {
-		subject, err := bfs.Connect(context.Background(), "scp://root:root@127.0.0.1:7022/prefix?tmpdir=test")
+		subject, err := bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix?tmpdir=test")
 		Expect(err).NotTo(HaveOccurred())
+		Expect(subject.Close()).To(Succeed())
+	})
+
+	It("should allow for absolute and relative paths", func() {
+		subject, err := bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix")
+		Expect(err).NotTo(HaveOccurred())
+
+		f, err := subject.Create(ctx, "test", nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(f.Commit()).To(Succeed())
+
+		i, err := subject.Head(ctx, "test")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(i).NotTo(BeNil())
+
+		Expect(subject.Close()).To(Succeed())
+
+		subject, err = bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix?absolute=true")
+		Expect(err).NotTo(HaveOccurred())
+		i, err = subject.Head(ctx, "test")
+		Expect(err).To(Equal(bfs.ErrNotFound))
+		Expect(i).To(BeNil())
+
 		Expect(subject.Close()).To(Succeed())
 	})
 

--- a/bfsscp/bfsscp_test.go
+++ b/bfsscp/bfsscp_test.go
@@ -32,13 +32,13 @@ var _ = Describe("Bucket", func() {
 	})
 
 	It("should register scp scheme", func() {
-		subject, err := bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix?tmpdir=test")
+		subject, err := bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/~/prefix?tmpdir=test")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(subject.Close()).To(Succeed())
 	})
 
 	It("should allow for absolute and relative paths", func() {
-		subject, err := bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix")
+		subject, err := bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/~/prefix")
 		Expect(err).NotTo(HaveOccurred())
 
 		f, err := subject.Create(ctx, "test", nil)
@@ -51,7 +51,7 @@ var _ = Describe("Bucket", func() {
 
 		Expect(subject.Close()).To(Succeed())
 
-		subject, err = bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix?absolute=true")
+		subject, err = bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix")
 		Expect(err).NotTo(HaveOccurred())
 		i, err = subject.Head(ctx, "test")
 		Expect(err).To(Equal(bfs.ErrNotFound))

--- a/bfsscp/bfsscp_test.go
+++ b/bfsscp/bfsscp_test.go
@@ -41,21 +41,22 @@ var _ = Describe("Bucket", func() {
 		subject, err := bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/~/prefix")
 		Expect(err).NotTo(HaveOccurred())
 
-		f, err := subject.Create(ctx, "test", nil)
+		file, err := subject.Create(ctx, "test", nil)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(f.Commit()).To(Succeed())
+		Expect(file.Commit()).To(Succeed())
 
-		i, err := subject.Head(ctx, "test")
+		info, err := subject.Head(ctx, "test")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(i).NotTo(BeNil())
+		Expect(info).NotTo(BeNil())
 
 		Expect(subject.Close()).To(Succeed())
 
 		subject, err = bfs.Connect(ctx, "scp://root:root@127.0.0.1:7022/prefix")
 		Expect(err).NotTo(HaveOccurred())
-		i, err = subject.Head(ctx, "test")
+
+		info, err = subject.Head(ctx, "test")
 		Expect(err).To(Equal(bfs.ErrNotFound))
-		Expect(i).To(BeNil())
+		Expect(info).To(BeNil())
 
 		Expect(subject.Close()).To(Succeed())
 	})


### PR DESCRIPTION
- Remove leading slash from Prefix when indicated with `~` or `.`
- Keep absolute paths as default