### PR TITLE
Support for custom S3 endpoint

### DIFF
--- a/bfss3/bfss3.go
+++ b/bfss3/bfss3.go
@@ -83,6 +83,14 @@ func init() {
 		if s := query.Get("region"); s != "" {
 			opts = append(opts, config.WithRegion(s))
 		}
+		if s := query.Get("endpoint"); s != "" {
+			opts = append(opts, config.WithEndpointResolver(aws.EndpointResolverFunc(func(service, region string) (aws.Endpoint, error) {
+				return aws.Endpoint{
+					URL:               s,
+					HostnameImmutable: true,
+				}, nil
+			})))
+		}
 		if s := query.Get("max_retries"); s != "" {
 			maxRetries, err := strconv.ParseInt(s, 10, 64)
 			if err != nil {


### PR DESCRIPTION
👋 Hi.

I want to use this project with a S3 compatible provider (DigitalOcean).
I'm not familiar with the AWS V2 SDK but I think I just only have to update the `EndpointProvider`.

Doing this change I was able to use with DigitalOcean with the following URL.
`s3://bucket?aws_access_key_id=KEY&aws_secret_access_key=SECRET&region=nyc3&endpoint=https://nyc3.digitaloceanspaces.com`

The **https://** part is very important.